### PR TITLE
fix: add colors object to useColorScheme hook

### DIFF
--- a/apps/mobile/src/lib/useColorScheme.ts
+++ b/apps/mobile/src/lib/useColorScheme.ts
@@ -1,10 +1,12 @@
 import { useColorScheme as useRNColorScheme } from "react-native";
+import { COLORS } from "@/theme/colors";
 
 export function useColorScheme() {
-  const colorScheme = useRNColorScheme();
+  const colorScheme = useRNColorScheme() ?? "light";
   return {
-    colorScheme: colorScheme ?? "light",
+    colorScheme,
     isDarkColorScheme: colorScheme === "dark",
+    colors: COLORS[colorScheme],
     toggleColorScheme: () => {
       // No-op — use system setting
     },


### PR DESCRIPTION
## Summary

- Wire `COLORS[colorScheme]` from `@/theme/colors` into the `useColorScheme` hook's return value so all nativewindui components get the `colors` object they expect.
- Move the `?? "light"` fallback to the variable assignment so `colorScheme` is never `null` when used as an index into `COLORS`.

Closes #5

## Test plan

- [ ] Launch the mobile app on iOS and Android simulators and confirm no crash on the home screen (LargeTitleHeader renders).
- [ ] Toggle the device between light and dark mode and verify colors update correctly.
- [ ] Spot-check a few nativewindui components (Alert, Button, TextField) to ensure they receive valid color values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)