### PR TITLE
fix: add bearer plugin and fix mobile auth token extraction

### DIFF
--- a/apps/mobile/src/lib/auth-client.ts
+++ b/apps/mobile/src/lib/auth-client.ts
@@ -40,16 +40,25 @@ async function authFetch<T = unknown>(
 
 export async function signIn(email: string, password: string) {
   try {
-    const result = await authFetch<{ user: Session["user"]; token: string }>(
-      "/api/auth/sign-in/email",
-      {
-        method: "POST",
-        body: JSON.stringify({ email, password }),
-      }
-    );
+    const res = await fetch(`${API_URL}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
 
-    await setSession({ user: result.user, token: result.token });
-    return result;
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(body || res.statusText);
+    }
+
+    const data = await res.json();
+
+    // Bearer plugin returns token in header; fallback to top-level body field
+    const headerToken = res.headers.get("set-auth-token");
+    const token = headerToken || data.token || "";
+
+    await setSession({ user: data.user, token });
+    return { user: data.user, token };
   } catch (error) {
     Sentry.captureException(error, { tags: { action: "sign_in" } });
     throw error;
@@ -62,20 +71,29 @@ export async function signUp(
   name?: string
 ) {
   try {
-    const result = await authFetch<{ user: Session["user"]; token: string }>(
-      "/api/auth/sign-up/email",
-      {
-        method: "POST",
-        body: JSON.stringify({ email, password, name }),
-      }
-    );
+    const res = await fetch(`${API_URL}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, name }),
+    });
 
-    await setSession({ user: result.user, token: result.token });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(body || res.statusText);
+    }
+
+    const data = await res.json();
+
+    // Bearer plugin returns token in header; fallback to top-level body field
+    const headerToken = res.headers.get("set-auth-token");
+    const token = headerToken || data.token || "";
+
+    await setSession({ user: data.user, token });
 
     // Send welcome email (fire-and-forget)
     sendWelcomeEmail(name || "", email).catch(() => {});
 
-    return result;
+    return { user: data.user, token };
   } catch (error) {
     Sentry.captureException(error, { tags: { action: "sign_up" } });
     throw error;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,14 +1,14 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
-import { admin } from "better-auth/plugins";
+import { admin, bearer } from "better-auth/plugins";
 import { getDb } from "@repo/db";
 import type { Auth } from "better-auth";
 
 // Construct the full auth type from better-auth's exported Auth generic,
 // parameterised with the plugins we actually use. No runtime variable needed.
 type AuthInstance = Auth<{
-  plugins: [ReturnType<typeof nextCookies>, ReturnType<typeof admin>];
+  plugins: [ReturnType<typeof nextCookies>, ReturnType<typeof admin>, ReturnType<typeof bearer>];
   database: ReturnType<typeof drizzleAdapter>;
 }>;
 
@@ -24,6 +24,7 @@ function initAuth(): AuthInstance {
     plugins: [
       nextCookies(),
       admin(),
+      bearer(),
     ],
     database: drizzleAdapter(getDb(), {
       provider: "pg",


### PR DESCRIPTION
## Summary

- Add `bearer()` plugin to Better-Auth server config so session tokens are returned via `set-auth-token` response header (required for non-browser clients like React Native)
- Fix mobile `signIn` and `signUp` to extract the token from the `set-auth-token` header (with fallback to top-level `data.token`), instead of expecting it nested in a session object

Closes #4

## Test plan

- [ ] Start the web app and verify `/api/auth/sign-in/email` returns a `set-auth-token` header
- [ ] Log in from the Expo mobile app and confirm the session token is stored correctly
- [ ] Sign up from the Expo mobile app and confirm the session token is stored and welcome email fires
- [ ] Verify authenticated mobile API calls (e.g. `GET /api/org`) succeed with the `Authorization: Bearer <token>` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)