### PR TITLE
fix: use port 3333 for React Email dev server

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -10,7 +10,7 @@
     "./subscription-canceled": "./src/subscription-canceled.tsx"
   },
   "scripts": {
-    "dev": "email dev --dir src",
+    "dev": "email dev --dir src --port 3333",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Fixes port conflict between React Email dev server and Next.js by adding `--port 3333` to the email package's dev script
- Next.js already moved to port 3003; React Email was still defaulting to 3000

Closes #10

## Test plan

- [ ] Run `pnpm dev` from root and verify both Next.js (port 3003) and React Email (port 3333) start without port conflicts
- [ ] Open `http://localhost:3333` and confirm React Email preview works

🤖 Generated with [Claude Code](https://claude.com/claude-code)