### PR TITLE
fix: allow mobile auth requests with missing origin

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -21,6 +21,9 @@ function initAuth(): AuthInstance {
     baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3003",
     basePath: "/api/auth",
     secret: process.env.BETTER_AUTH_SECRET || "dev-secret-key",
+    // Allow requests with missing/null Origin (React Native doesn't send one).
+    // TODO: restrict to specific origins in production.
+    trustedOrigins: ["*"],
     plugins: [
       nextCookies(),
       admin(),


### PR DESCRIPTION
## Summary
- React Native `fetch()` does not send an `Origin` header, causing Better-Auth to reject all mobile auth requests.
- Adds `trustedOrigins: ["*"]` to the `betterAuth()` config in `apps/web/src/lib/auth.ts` so requests with missing or null origin are accepted.
- Includes a TODO comment to restrict trusted origins in production.

Closes #11

## Test plan
- [ ] Verify mobile app can sign in / sign up without origin-related errors
- [ ] Verify web auth still works normally (browser sends Origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)