### PR TITLE
fix: patch 5 critical security vulnerabilities

### DIFF
--- a/apps/web/src/app/api/__tests__/portal.test.ts
+++ b/apps/web/src/app/api/__tests__/portal.test.ts
@@ -27,8 +27,9 @@ vi.mock("@repo/db", () => ({
   getDb: () => ({
     select: mockSelect,
   }),
-  userSubscriptions: { stripeCustomerId: "stripeCustomerId", email: "email" },
+  userSubscriptions: { stripeCustomerId: "stripeCustomerId", email: "email", userId: "userId" },
   eq: vi.fn(),
+  and: vi.fn(),
 }));
 
 vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));

--- a/apps/web/src/app/api/email/welcome/route.ts
+++ b/apps/web/src/app/api/email/welcome/route.ts
@@ -1,14 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { sendWelcomeEmail } from '@/lib/email';
+import { auth } from '@/lib/auth';
+import { checkRateLimit } from '@/lib/rate-limit';
 import * as Sentry from '@sentry/nextjs';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(req: NextRequest) {
   try {
+    // Require authenticated session
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Rate limit per user
+    const allowed = await checkRateLimit(`welcome-email:${session.user.id}`);
+    if (!allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        { status: 429 }
+      );
+    }
+
     const { name, email } = await req.json();
 
     if (!email || !name) {
       return NextResponse.json(
         { error: 'Email and name are required' },
+        { status: 400 }
+      );
+    }
+
+    if (!EMAIL_REGEX.test(email)) {
+      return NextResponse.json(
+        { error: 'Invalid email format' },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/api/portal/route.ts
+++ b/apps/web/src/app/api/portal/route.ts
@@ -3,7 +3,7 @@ import Stripe from "stripe";
 import { auth } from "@/lib/auth";
 import { checkRateLimit } from "@/lib/rate-limit";
 import * as Sentry from "@sentry/nextjs";
-import { getDb, userSubscriptions, eq } from "@repo/db";
+import { getDb, userSubscriptions, eq, and } from "@repo/db";
 
 // Lazy initialize Stripe client (only when needed)
 let stripeClient: Stripe | null = null;
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     const [sub] = await db
       .select({ stripeCustomerId: userSubscriptions.stripeCustomerId })
       .from(userSubscriptions)
-      .where(eq(userSubscriptions.email, session.user.email))
+      .where(and(eq(userSubscriptions.email, session.user.email), eq(userSubscriptions.userId, session.user.id)))
       .limit(1);
 
     const customerId = sub?.stripeCustomerId;

--- a/apps/web/src/app/api/webhooks/revenuecat/route.ts
+++ b/apps/web/src/app/api/webhooks/revenuecat/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { sendPaymentFailedEmail } from "@/lib/email";
@@ -34,7 +35,11 @@ function verifyWebhookSignature(request: NextRequest): boolean {
   }
 
   const token = authHeader.replace(/^Bearer\s+/i, "");
-  return token === secret;
+  try {
+    return timingSafeEqual(Buffer.from(token), Buffer.from(secret));
+  } catch {
+    return false;
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -22,7 +22,7 @@ function initAuth(): AuthInstance {
     secret: process.env.BETTER_AUTH_SECRET || "dev-secret-key",
     // Allow requests with missing/null Origin (React Native doesn't send one).
     // TODO: restrict to specific origins in production.
-    trustedOrigins: ["*"],
+    trustedOrigins: (process.env.TRUSTED_ORIGINS || "http://localhost:3003").split(","),
     emailAndPassword: {
       enabled: true,
     },

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -13,15 +13,19 @@ function getResend(): Resend {
   return resend;
 }
 
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 export async function sendWelcomeEmail(name: string, email: string) {
   try {
     const result = await getResend().emails.send({
       from: process.env.RESEND_FROM_EMAIL || 'noreply@example.com',
       to: email,
-      subject: `Welcome ${name}!`,
+      subject: `Welcome ${escapeHtml(name)}!`,
       html: `
         <h1>Welcome to our platform!</h1>
-        <p>Hi ${name},</p>
+        <p>Hi ${escapeHtml(name)},</p>
         <p>Thanks for signing up. We're excited to have you on board.</p>
         <p>Get started by logging into your dashboard.</p>
       `,


### PR DESCRIPTION
## Summary

- **trustedOrigins wildcard**: Replace `["*"]` in Better-Auth config with env-configurable `TRUSTED_ORIGINS`, defaulting to `http://localhost:3003`
- **Unauthenticated email endpoint**: Add session auth, rate limiting, and email format validation to `POST /api/email/welcome`
- **Portal IDOR**: Add `userId` check to Stripe portal subscription lookup so users cannot access other users' billing portals by email collision
- **XSS in email templates**: Add `escapeHtml()` helper and apply it to user-provided values interpolated into HTML email bodies
- **Timing attack on RevenueCat webhook**: Replace `===` bearer token comparison with `crypto.timingSafeEqual` to prevent timing-based secret extraction

## Test plan

- [x] `pnpm typecheck` passes (all 4 tasks)
- [x] `pnpm test` passes (55/55 tests, including updated portal test mock)
- [ ] Verify `TRUSTED_ORIGINS` env var is set in production deployment
- [ ] Verify welcome email endpoint still works with valid auth session
- [ ] Verify Stripe portal access still works for authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)